### PR TITLE
Allow driver to recover on USB disconnect / reconnect

### DIFF
--- a/src/kangaroo_driver.cpp
+++ b/src/kangaroo_driver.cpp
@@ -319,6 +319,8 @@ bool kangaroo::send_get_request(unsigned char address, char channel, unsigned ch
 	if (0 > write(fd, buffer, num_of_bytes))
 	{
 		ROS_ERROR("Failed to write to serial.");
+		close();
+		fd = -1;
 		return false;
 	}
 
@@ -510,6 +512,7 @@ void kangaroo::handle_errors(unsigned char address, int error_code)
 		ROS_ERROR("The given parameter is unknown.");
 		break;
 	case 6:
+		send_start_signals(address);
 		ROS_ERROR("Serial timeout occurred.");
 		break;
 	default:


### PR DESCRIPTION
# Overcoming intermittent USB connection issues
## Background / Problem
We have gotten good use out of this driver, but have had a chronic issue of the kangaroos occasionally dropping out, causing *erroneous* behavior (i.e. careening across the lab, sparing no shin, wall, or scientist).

Our platform (Jetson TX2) seems to be prone to occasional USB reset events, and when this occurs, the driver is left in a state of continuing to attempt to write to a file descriptor that is no longer valid.

## Solution
My solution to this is to close the port, and attempt to reopen. If it is a momentary blip, then when the device reappears on the device list, it will be reopened with a new, valid file descriptor.

### Line-by-Line:
Line 322: `close()` calls the method for closing the port
Line 323: `fd = -1;` will make `is_open()` return `false`.
Line 515: When this reset occurs, the kangaroo sometimes finds itself in a timeout state. Calling `send_start_signals(address)` if a timeout error is received will clear the error and restart the device.

Hopefully this will help someone else experiencing the same issues!

--Hal Jarrett, Georgia Tech Research Institute